### PR TITLE
fix changelog order

### DIFF
--- a/sdk/content-components/CHANGELOG.md
+++ b/sdk/content-components/CHANGELOG.md
@@ -1,29 +1,29 @@
- ## 0.6.0 (June 16, 2022)
+## 0.6.0 (June 16, 2022)
 
- - Added ability to export PDFs for reports via the context menu
+- Added ability to export PDFs for reports via the context menu
 
- ## 0.5.0 (March 17, 2022)
+## 0.5.0 (March 17, 2022)
 
- - Added table view and controls to ContentAreaElement
+- Added table view and controls to ContentAreaElement
 
- ## 0.4.0 (February 21, 2022)
+## 0.4.0 (February 21, 2022)
 
- - Added ContentTreeElement
- - Added ContentBreadcrumbElement
- - Added ContentGroupElement
- - BREAKING CHANGE: Removed `folderIdentifier` and `itemIdentifiers` properties from ContentAreaElement. The `initialNavigationValue` property of ContentGroupElement is recommended instead.
- - Added the `authentication-type` attribute to components to specify whether to use credentials or guest authentication.
+- Added ContentTreeElement
+- Added ContentBreadcrumbElement
+- Added ContentGroupElement
+- BREAKING CHANGE: Removed `folderIdentifier` and `itemIdentifiers` properties from ContentAreaElement. The `initialNavigationValue` property of ContentGroupElement is recommended instead.
+- Added the `authentication-type` attribute to components to specify whether to use credentials or guest authentication.
 
- ## 0.3.0 (December 15, 2021)
+## 0.3.0 (December 15, 2021)
 
- - Internal dependency update
+- Internal dependency update
 
 ## 0.2.0 (November 18, 2021)
 
 - New ContentAreaElement features:
- - `selection-mode` attribute to choose between single and multiple selection.
- - `initial-selection-index` attribute to set a default initial selection when content details are not known.
- - `setSelectedIdentifiers` method to allow for updating the selection programmatically.
- ## 0.1.0 (September 20, 2021)
+- `selection-mode` attribute to choose between single and multiple selection.
+- `initial-selection-index` attribute to set a default initial selection when content details are not known.
+- `setSelectedIdentifiers` method to allow for updating the selection programmatically.
+## 0.1.0 (September 20, 2021)
 
 - First release

--- a/sdk/content-components/CHANGELOG.md
+++ b/sdk/content-components/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `selection-mode` attribute to choose between single and multiple selection.
 - `initial-selection-index` attribute to set a default initial selection when content details are not known.
 - `setSelectedIdentifiers` method to allow for updating the selection programmatically.
+
 ## 0.1.0 (September 20, 2021)
 
 - First release

--- a/sdk/content-components/CHANGELOG.md
+++ b/sdk/content-components/CHANGELOG.md
@@ -1,17 +1,10 @@
-## 0.1.0 (September 20, 2021)
+ ## 0.6.0 (June 16, 2022)
 
-- First release
+ - Added ability to export PDFs for reports via the context menu
 
-## 0.2.0 (November 18, 2021)
+ ## 0.5.0 (March 17, 2022)
 
-- New ContentAreaElement features:
- - `selection-mode` attribute to choose between single and multiple selection.
- - `initial-selection-index` attribute to set a default initial selection when content details are not known.
- - `setSelectedIdentifiers` method to allow for updating the selection programmatically.
-
- ## 0.3.0 (December 15, 2021)
-
- - Internal dependency update
+ - Added table view and controls to ContentAreaElement
 
  ## 0.4.0 (February 21, 2022)
 
@@ -21,10 +14,16 @@
  - BREAKING CHANGE: Removed `folderIdentifier` and `itemIdentifiers` properties from ContentAreaElement. The `initialNavigationValue` property of ContentGroupElement is recommended instead.
  - Added the `authentication-type` attribute to components to specify whether to use credentials or guest authentication.
 
- ## 0.5.0 (March 17, 2022)
+ ## 0.3.0 (December 15, 2021)
 
- - Added table view and controls to ContentAreaElement
+ - Internal dependency update
 
- ## 0.6.0 (June 16, 2022)
+## 0.2.0 (November 18, 2021)
 
- - Added ability to export PDFs for reports via the context menu
+- New ContentAreaElement features:
+ - `selection-mode` attribute to choose between single and multiple selection.
+ - `initial-selection-index` attribute to set a default initial selection when content details are not known.
+ - `setSelectedIdentifiers` method to allow for updating the selection programmatically.
+ ## 0.1.0 (September 20, 2021)
+
+- First release

--- a/sdk/va-report-components/CHANGELOG.md
+++ b/sdk/va-report-components/CHANGELOG.md
@@ -160,6 +160,7 @@
 - Add support for SAS Visual Analytics 8.5
 - Add support for `<sas-report-page>` custom element for embedding a report page.
 - Additional bug fixes
+
 ## 0.2.0 (October 2, 2019)
 
 - Add support for authenticationType='credentials'.

--- a/sdk/va-report-components/CHANGELOG.md
+++ b/sdk/va-report-components/CHANGELOG.md
@@ -1,67 +1,97 @@
-## 0.2.0 (October 2, 2019)
+## 1.9.0 (June 16, 2022)
 
-- Add support for authenticationType='credentials'.
-- Change authenticationType default from 'guest' to 'credentials'.
-- Fix issues where report link context menu not always working as expected.
-- Improved handling of report images and fixed an issue where report images would log unauthenticated users in as guest.
-
-## 0.3.0 (November 19, 2019)
-
-- Add support for SAS Visual Analytics 8.5
-- Add support for `<sas-report-page>` custom element for embedding a report page.
-- Additional bug fixes
-
-## 0.4.0 (April 8, 2020)
-
-- Add ReportHandle API with support for report parameters
+- SAS Viya 2022.1.2 support (Report Package version 25)
 - Bug fixes
 
-## 0.5.0 (May 27, 2020)
+## 1.8.0 (May 19, 2022)
 
-- Add support for custom report themes
-- Add support for SAS Graphics Accelerator
-- Keyboard and focus accessibility fixes
+- SAS Viya 2022.1.1 support (Report Package version 25)
 - Bug fixes
 
-## 0.6.0 (June 26, 2020)
+## 1.7.0 (April 21, 2022)
 
+- SAS Viya 2021.2.6 support (Report Package version 24)
+- SAS Viya 2022.1 LTS support
 - Bug fixes
 
-## 0.7.0 (July 24, 2020)
+## 1.6.0 (March 17, 2022)
 
+- SAS Viya 2021.2.5 support (Report Package version 23)
+- Support SAS Viya fonts with exported SAS Report Packages
 - Bug fixes
 
-## 0.8.0 (August 18, 2020)
+## 1.5.0 (February 17, 2022)
 
-- SAS Viya 2020.0.4 support
+- SAS Viya 2021.2.4 support
 - Bug fixes
 
-## 0.9.0 (September 16, 2020)
+## 1.4.0 (January 19, 2022)
 
-- Add support for custom menu items with MenuItemProvider API
-- SAS Viya 2020.0.5 support
+- SAS Viya 2021.2.3 support
 - Bug fixes
 
-## 0.10.0 (October 20, 2020)
+## 1.3.0 (December 15, 2021)
 
-- Add exportPDF API
-- SAS Viya 2020.0.6 support
+- SAS Viya 2021.2.2 support
+- Support custom report themes with exported SAS Report Packages
 - Bug fixes
 
-## 0.11.0 (November 19, 2020)
+## 1.2.0 (November 18, 2021)
 
-- SAS Viya 2020.0.7 support
+- SAS Viya 2021.2.1 support
+- Support setUseHighContrastReportTheme API with exported SAS Report Packages
 - Bug fixes
 
-## 0.12.0 (December 16, 2020)
+## 1.1.0 (October 20, 2021)
 
-- Page link navigation breadcrumb
-- SAS Viya 2020.1.1 support
+- SAS Viya 2021.1.6 support
+- SAS Viya 2021.2 LTS support
+- Add exportData API (ObjectHandle)
 - Bug fixes
 
-## 0.13.0 (January 20, 2021)
+## 1.0.0 (September 15, 2021)
 
-- SAS Viya 2020.1.2 support
+- SAS Viya 2021.1.5 support
+- Add enablePdfAccessibleTags to ExportPDFOptions
+- Add packageUri API and support exported SAS Report Packages
+- Bug fixes
+
+## 0.20.0 (August 18, 2021)
+
+- SAS Viya 2021.1.4 support
+- Add reloadReport API (ReportHandle)
+- Add support for object maximize and detailed data
+- Bug fixes
+
+## 0.19.0 (July 21, 2021)
+
+- SAS Viya 2021.1.3 support
+- Add setLoadingTheme API
+- Bug fixes
+
+## 0.18.0 (June 16, 2021)
+
+- SAS Viya 2021.1.2 support
+- Add getObjectHandle API
+- Add refreshData API (ReportHandle and ObjectHandle)
+- Bug fixes
+
+## 0.17.0 (May 19, 2021)
+
+- SAS Viya 2021.1.1 support
+- Bug fixes
+
+## 0.16.0 (April 20, 2021)
+
+- Support for select all option on list control
+- SAS Viya 2020.1.5 support
+- Bug fixes
+
+## 0.15.0 (March 18, 2021)
+
+- Map element drag mode controls
+- Support for searchable option on list control
+- SAS Viya 2020.1.4 support
 - Bug fixes
 
 ## 0.14.0 (February 17, 2021)
@@ -72,98 +102,67 @@
 - SAS Viya 2020.1.3 support
 - Bug fixes
 
-## 0.15.0 (March 18, 2021)
+## 0.13.0 (January 20, 2021)
 
-- Map element drag mode controls
-- Support for searchable option on list control
-- SAS Viya 2020.1.4 support
+- SAS Viya 2020.1.2 support
 - Bug fixes
 
-## 0.16.0 (April 20, 2021)
+## 0.12.0 (December 16, 2020)
 
-- Support for select all option on list control
-- SAS Viya 2020.1.5 support
+- Page link navigation breadcrumb
+- SAS Viya 2020.1.1 support
 - Bug fixes
 
-## 0.17.0 (May 19, 2021)
+## 0.11.0 (November 19, 2020)
 
-- SAS Viya 2021.1.1 support
+- SAS Viya 2020.0.7 support
 - Bug fixes
 
-## 0.18.0 (June 16, 2021)
+## 0.10.0 (October 20, 2020)
 
-- SAS Viya 2021.1.2 support
-- Add getObjectHandle API
-- Add refreshData API (ReportHandle and ObjectHandle)
+- Add exportPDF API
+- SAS Viya 2020.0.6 support
 - Bug fixes
 
-## 0.19.0 (July 21, 2021)
+## 0.9.0 (September 16, 2020)
 
-- SAS Viya 2021.1.3 support
-- Add setLoadingTheme API
+- Add support for custom menu items with MenuItemProvider API
+- SAS Viya 2020.0.5 support
 - Bug fixes
 
-## 0.20.0 (August 18, 2021)
+## 0.8.0 (August 18, 2020)
 
-- SAS Viya 2021.1.4 support
-- Add reloadReport API (ReportHandle)
-- Add support for object maximize and detailed data
+- SAS Viya 2020.0.4 support
 - Bug fixes
 
-## 1.0.0 (September 15, 2021)
+## 0.7.0 (July 24, 2020)
 
-- SAS Viya 2021.1.5 support
-- Add enablePdfAccessibleTags to ExportPDFOptions
-- Add packageUri API and support exported SAS Report Packages
 - Bug fixes
 
-## 1.1.0 (October 20, 2021)
+## 0.6.0 (June 26, 2020)
 
-- SAS Viya 2021.1.6 support
-- SAS Viya 2021.2 LTS support
-- Add exportData API (ObjectHandle)
 - Bug fixes
 
-## 1.2.0 (November 18, 2021)
+## 0.5.0 (May 27, 2020)
 
-- SAS Viya 2021.2.1 support
-- Support setUseHighContrastReportTheme API with exported SAS Report Packages
+- Add support for custom report themes
+- Add support for SAS Graphics Accelerator
+- Keyboard and focus accessibility fixes
 - Bug fixes
 
-## 1.3.0 (December 15, 2021)
+## 0.4.0 (April 8, 2020)
 
-- SAS Viya 2021.2.2 support
-- Support custom report themes with exported SAS Report Packages
+- Add ReportHandle API with support for report parameters
 - Bug fixes
 
-## 1.4.0 (January 19, 2022)
+## 0.3.0 (November 19, 2019)
 
-- SAS Viya 2021.2.3 support
-- Bug fixes
+- Add support for SAS Visual Analytics 8.5
+- Add support for `<sas-report-page>` custom element for embedding a report page.
+- Additional bug fixes
+## 0.2.0 (October 2, 2019)
 
-## 1.5.0 (February 17, 2022)
-
-- SAS Viya 2021.2.4 support
-- Bug fixes
-
-## 1.6.0 (March 17, 2022)
-
-- SAS Viya 2021.2.5 support (Report Package version 23)
-- Support SAS Viya fonts with exported SAS Report Packages
-- Bug fixes
-
-## 1.7.0 (April 21, 2022)
-
-- SAS Viya 2021.2.6 support (Report Package version 24)
-- SAS Viya 2022.1 LTS support
-- Bug fixes
-
-## 1.8.0 (May 19, 2022)
-
-- SAS Viya 2022.1.1 support (Report Package version 25)
-- Bug fixes
-
-## 1.9.0 (June 16, 2022)
-
-- SAS Viya 2022.1.2 support (Report Package version 25)
-- Bug fixes
+- Add support for authenticationType='credentials'.
+- Change authenticationType default from 'guest' to 'credentials'.
+- Fix issues where report link context menu not always working as expected.
+- Improved handling of report images and fixed an issue where report images would log unauthenticated users in as guest.


### PR DESCRIPTION
The changelog should be in reverse chronological order.  Changing this for both va-report-components and content-components.