### PR TITLE
add documentation for restrictViewportGestures

### DIFF
--- a/sdk/va-report-components/documentation/docs/api/SASReportElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportElement.md
@@ -54,7 +54,7 @@ default value: `'auto'`
 
 ### `restrictViewportGestures: boolean`
 
-If `true`, some interactive viewport features may be restricted. Currently the only restriction is that a modifier key is required to enable zooming with the scroll wheel. When the user engages the scroll wheel a transluecent overlay is placed over the visual with a message indicating which modifier key is required to enable zooming. The overlay disappears when the key is pressed.
+When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Use the modifier key when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
 
 default value: `false`
 

--- a/sdk/va-report-components/documentation/docs/api/SASReportElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportElement.md
@@ -54,7 +54,7 @@ default value: `'auto'`
 
 ### `restrictViewportGestures: boolean`
 
-When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Use the modifier key when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
+When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Enable restrictViewportGestures when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
 
 default value: `false`
 

--- a/sdk/va-report-components/documentation/docs/api/SASReportElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportElement.md
@@ -52,6 +52,12 @@ than one section.
 
 default value: `'auto'`
 
+### `restrictViewportGestures: boolean`
+
+If `true`, some interactive viewport features may be restricted. Currently the only restriction is that a modifier key is required to enable zooming with the scroll wheel. When the user engages the scroll wheel a transluecent overlay is placed over the visual with a message indicating which modifier key is required to enable zooming. The overlay disappears when the key is pressed.
+
+default value: `false`
+
 ## Properties
 
 ### `menuItemProvider: MenuItemProvider`

--- a/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
@@ -49,6 +49,12 @@ See [Export Report Package](guides/export-report-package.md)
 
 Specify the name of the object from the report to display.
 
+### `restrictViewportGestures: boolean`
+
+If `true`, some interactive viewport features may be restricted. Currently the only restriction is that a modifier key is required to enable zooming with the scroll wheel. When the user engages the scroll wheel a transluecent overlay is placed over the visual with a message indicating which modifier key is required to enable zooming. The overlay disappears when the key is pressed.
+
+default value: `true`
+
 ## Properties
 
 ### `menuItemProvider: MenuItemProvider`

--- a/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
@@ -51,7 +51,7 @@ Specify the name of the object from the report to display.
 
 ### `restrictViewportGestures: boolean`
 
-If `true`, some interactive viewport features may be restricted. Currently the only restriction is that a modifier key is required to enable zooming with the scroll wheel. When the user engages the scroll wheel a transluecent overlay is placed over the visual with a message indicating which modifier key is required to enable zooming. The overlay disappears when the key is pressed.
+When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Use the modifier key when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
 
 default value: `true`
 

--- a/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
@@ -51,7 +51,7 @@ Specify the name of the object from the report to display.
 
 ### `restrictViewportGestures: boolean`
 
-When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Use the modifier key when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
+When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Enable restrictViewportGestures when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
 
 default value: `true`
 

--- a/sdk/va-report-components/documentation/docs/api/SASReportPageElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportPageElement.md
@@ -54,7 +54,7 @@ Specify the index of the report page that you want to display. `0` is the first 
 
 ### `restrictViewportGestures: boolean`
 
-When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Use the modifier key when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
+When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Enable restrictViewportGestures when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
 
 default value: `true`
 

--- a/sdk/va-report-components/documentation/docs/api/SASReportPageElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportPageElement.md
@@ -52,6 +52,12 @@ Specify the name of the report page that you want to display. Either `pageName` 
 
 Specify the index of the report page that you want to display. `0` is the first page. Either `pageName` or `pageIndex` can be used, but not both.
 
+### `restrictViewportGestures: boolean`
+
+If `true`, some interactive viewport features may be restricted. Currently the only restriction is that a modifier key is required to enable zooming with the scroll wheel. When the user engages the scroll wheel a transluecent overlay is placed over the visual with a message indicating which modifier key is required to enable zooming. The overlay disappears when the key is pressed.
+
+default value: `true`
+
 ## Properties
 
 ### `menuItemProvider: MenuItemProvider`

--- a/sdk/va-report-components/documentation/docs/api/SASReportPageElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportPageElement.md
@@ -54,7 +54,7 @@ Specify the index of the report page that you want to display. `0` is the first 
 
 ### `restrictViewportGestures: boolean`
 
-If `true`, some interactive viewport features may be restricted. Currently the only restriction is that a modifier key is required to enable zooming with the scroll wheel. When the user engages the scroll wheel a transluecent overlay is placed over the visual with a message indicating which modifier key is required to enable zooming. The overlay disappears when the key is pressed.
+When `true`, report objects that support zooming require a modifier key be used in addition to the scroll wheel. Use the modifier key when embedding elements in a layout that causes overflow. This reserves the scroll-wheel action for page scrolling.
 
 default value: `true`
 


### PR DESCRIPTION
This feature was added to improve the user experience while scrolling a page that contains report objects. It is easy to get stuck in a graph while scrolling. As you are scrolling the page the mouse enters a graph and starts zooming the graph instead of scrolling the page. With restrictViewportGestures turned on, the zooming does not happen by default. The user is required to press a modifier key to engage the zoom. On mac this is the cmd key, while on windows it will be the ctrl key.