### PR TITLE
add documentation for setLocale

### DIFF
--- a/sdk/va-report-components/documentation/docs/api-reference.md
+++ b/sdk/va-report-components/documentation/docs/api-reference.md
@@ -16,6 +16,7 @@ to use SAS data to drive your own components or visualizations.
 - [`DataDrivenContentHandle`](api/DataDrivenContentHandle.md)
 - [`setUseHighContrastReportTheme`](api/setUseHighContrastReportTheme.md)
 - [`setLoadingTheme`](api/setLoadingTheme.md)
+- [`setLocale`](api/setLocale.md)
 
 ## Loading with \<script\>
 

--- a/sdk/va-report-components/documentation/docs/api/setLocale.md
+++ b/sdk/va-report-components/documentation/docs/api/setLocale.md
@@ -1,0 +1,30 @@
+---
+id: setLocale
+title: setLocale
+---
+
+```
+setLocale(locale): void
+```
+
+`setLocale` allows the user to set an override to the language specified in the browser settings.
+
+## Arguments
+
+### `locale: string`
+
+The locale should be specified as a language code and optional country code. This is the same format used by [navigator.language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language)
+
+### Examples
+
+```javascript
+window.addEventListener("vaReportComponents.loaded", function () {
+  vaReportComponents.setLocale("fr");
+});
+```
+
+```javascript
+window.addEventListener("vaReportComponents.loaded", function () {
+  vaReportComponents.setLocale("fr-CA");
+});
+```

--- a/sdk/va-report-components/documentation/docs/api/setLocale.md
+++ b/sdk/va-report-components/documentation/docs/api/setLocale.md
@@ -7,7 +7,7 @@ title: setLocale
 setLocale(locale): void
 ```
 
-`setLocale` allows the user to set an override to the language specified in the browser settings.
+`setLocale` enables the user to set an override for the language that is specified in the browser settings.
 
 ## Arguments
 

--- a/sdk/va-report-components/documentation/website/sidebars.json
+++ b/sdk/va-report-components/documentation/website/sidebars.json
@@ -17,7 +17,8 @@
       "api/DataDrivenContentHandle",
       "api/ReportObjectResultData",
       "api/setUseHighContrastReportTheme",
-      "api/setLoadingTheme"
+      "api/setLoadingTheme",
+      "api/setLocale"
     ],
     "Resources": ["faq"]
   }


### PR DESCRIPTION
This adds documentation for setLocale, which sets the locale used by va-sdk to be something different that the broswer setting.