### PR TITLE
add documentation for setFormatterLocale

### DIFF
--- a/sdk/va-report-components/documentation/docs/api-reference.md
+++ b/sdk/va-report-components/documentation/docs/api-reference.md
@@ -17,6 +17,7 @@ to use SAS data to drive your own components or visualizations.
 - [`setUseHighContrastReportTheme`](api/setUseHighContrastReportTheme.md)
 - [`setLoadingTheme`](api/setLoadingTheme.md)
 - [`setLocale`](api/setLocale.md)
+- [`setLocale`](api/setFormatterLocale.md)
 
 ## Loading with \<script\>
 

--- a/sdk/va-report-components/documentation/docs/api/setFormatterLocale.md
+++ b/sdk/va-report-components/documentation/docs/api/setFormatterLocale.md
@@ -1,0 +1,30 @@
+---
+id: setFormatterLocale
+title: setFormatterLocale
+---
+
+```
+setFormatterLocale(locale): void
+```
+
+`setFormatterLocale` enables the user to set a language to be used for formatting numeric values and dates. If not specified this will fallback to either the language specified by calling setLocale, or the language specified in the browser settings.
+
+## Arguments
+
+### `locale: string | null`
+
+The locale should be specified as a language code and optional country code. This is the same format used by [navigator.language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language)
+
+### Examples
+
+```javascript
+window.addEventListener("vaReportComponents.loaded", function () {
+  vaReportComponents.setFormatterLocale("fr");
+});
+```
+
+```javascript
+window.addEventListener("vaReportComponents.loaded", function () {
+  vaReportComponents.setFormatterLocale("fr-CA");
+});
+```

--- a/sdk/va-report-components/documentation/docs/api/setFormatterLocale.md
+++ b/sdk/va-report-components/documentation/docs/api/setFormatterLocale.md
@@ -7,13 +7,13 @@ title: setFormatterLocale
 setFormatterLocale(locale): void
 ```
 
-`setFormatterLocale` enables the user to set a language to be used for formatting numeric values and dates. If not specified this will fallback to either the language specified by calling setLocale, or the language specified in the browser settings.
+`setFormatterLocale` enables the user to set the language that is used to format numeric values and dates. If not specified, the language will fallback to the one that is specified by calling setLocale or the one is specified in the browser settings.
 
 ## Arguments
 
 ### `locale: string | null`
 
-The locale should be specified as a language code and optional country code. This is the same format used by [navigator.language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language)
+The locale should be specified as a language code and an optional country code. This is the same format that is used by [navigator.language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language)
 
 ### Examples
 

--- a/sdk/va-report-components/documentation/docs/api/setLocale.md
+++ b/sdk/va-report-components/documentation/docs/api/setLocale.md
@@ -11,9 +11,9 @@ setLocale(locale): void
 
 ## Arguments
 
-### `locale: string`
+### `locale: string | null`
 
-The locale should be specified as a language code and optional country code. This is the same format used by [navigator.language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language)
+The locale should be specified as a language code and an optional country code. This is the same format that is used by [navigator.language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language)
 
 ### Examples
 

--- a/sdk/va-report-components/documentation/website/sidebars.json
+++ b/sdk/va-report-components/documentation/website/sidebars.json
@@ -18,7 +18,8 @@
       "api/ReportObjectResultData",
       "api/setUseHighContrastReportTheme",
       "api/setLoadingTheme",
-      "api/setLocale"
+      "api/setLocale",
+      "api/setFormatterLocale"
     ],
     "Resources": ["faq"]
   }


### PR DESCRIPTION
This adds documentation for setFormatterLocale, which sets the locale used by va-sdk for numeric values and dates to be something different than the value set by setLocale and the broswer setting.