### PR TITLE
fix content sdk viya setup doc

### DIFF
--- a/sdk/content-components/documentation/docs/getting-started.md
+++ b/sdk/content-components/documentation/docs/getting-started.md
@@ -39,30 +39,29 @@ When the library is used in production, consider pinning it to an explicit versi
 
 ## SAS Viya setup
 
-### Enable Cross-Origin Resource Sharing
+## Enable Cross-Origin Resource Sharing
 
 By default, your SAS Viya deployment is not set up to allow access to REST API endpoints from different domains. This is
 needed in order to connect to SAS Viya from the domain that is hosting your HTML page. This domain needs to be added to the
-`allowOrigins` property in SAS Viya deployment's CORS configuration. See
-<a target="_blank" href="https://developer.sas.com/reference/cors/">developer.sas.com</a> and
-<a target="_blank" href="https://go.documentation.sas.com/doc/en/sasadmincdc/v_023/calauthmdl/n1iyx40th7exrqn1ej8t12gfhm88.htm#p04ifnaixhf85in1xo7zrr2fgimf">SAS Help Center</a> for more information.
+`allowOrigins` property in SAS Viya deployment's CORS configuration. This can be done by following the <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=n1iyx40th7exrqn1ej8t12gfhm88.htm#p04ifnaixhf85in1xo7zrr2fgimf">Configure Cross-Origin Resource Sharing</a> documentation. Note that the `allowedOrigins` property does not support using the value `*` to support all origins. You must explicitly add your domain or a list of domains.
 
-### Cross-Site Request Forgery
+## Cross-Site Request Forgery
 
-SAS Viya servers protect against Cross-Site Request Forgery (CSRF) by blocking requests where the HTTP Referer Header does not match the URI of the requested resource or a URI allowlist. The domain of the site using the SAS Content SDK must be allowlisted in the CSRF configuration.  See <a target="_blank" href="https://go.documentation.sas.com/doc/en/sasadmincdc/v_023/calconfigref/p1fejrlg8b007jn1krvvwzy5q7tn.htm#n0nf0wwa3p7mjhn11926x4k9gl72">SAS Help Center</a> for more information.
+SAS Viya protects against Cross-Site Request Forgery (CSRF) by blocking requests where the HTTP Referer Header does not match the URI of the requested resource or the `allowedUris` CSRF configuration property. The domain of the site using the SAS Content SDK must be allowed in the CSRF configuration by setting `allowedUris` to a regular expression that matches the domain. For example, the regular expression `.*` will match all domains.  See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calconfigref&docsetTarget=p1fejrlg8b007jn1krvvwzy5q7tn.htm#n0nf0wwa3p7mjhn11926x4k9gl72">SAS Help Center</a> for more information.
 
-### Cross-Site Cookies
+## Cross-Site Cookies
 
-The SAS Content SDK requires the use of cookies to handle authentication with the SAS Viya Logon service. Browsers require that the response setting the cookie explicitly enable cross-site cookies by setting `samesite=none` on the response header. This is not the default for SAS Viya and must be configured in order to support the SDK. The `sameSite` configuration option in the `sas.commons.web.security.cookies` definition should be set to `None`, and should be applied globally to all services. See <a target="_blank" href="https://go.documentation.sas.com/doc/en/sasadmincdc/v_023/calconfigref/p1fejrlg8b007jn1krvvwzy5q7tn.htm#p0xav129qcxrytn14y2d8rnhdrlm">SAS Help Center</a> for more information.
+The SAS Content SDK requires the use of cookies to handle authentication with the SAS Viya Logon service. Browsers require that the response setting the cookie explicitly enable cross-site cookies by setting `samesite=none` on the response header. This is not the default for SAS Viya, so you must configure it to support the SAS Content SDK. The `sameSite` configuration option in the `sas.commons.web.security.cookies` definition should be set to `None`, and should be applied globally to all services. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calauthmdl&docsetTarget=n1iyx40th7exrqn1ej8t12gfhm88.htm#p18ctm7c29p2z3n1cahhb0qvwaa6">SAS Help Center</a> for more information.
 
-#### HTTPS
-It is also a requirement that SAS Viya be accessed using the HTTPS protocol in order for web browsers to allow cross-site cookies to be set by SAS Viya.  This requires that TLS (Transport Layer Security) be enabled on your SAS Viya deployment. See <a target="_blank" href="https://go.documentation.sas.com/doc/en/sasadmincdc/v_023/viyaov/p0i3vcgjpciz45n1of1v4vkffwbn.htm?fromDefault=#p1xrvoju01719fn1trks0xkasjk5">SAS Help Center</a> for more information.
+Note: If you have enabled settings that block cookies in your web browser, then the SAS Content SDK cannot authenticate with SAS Viya. Check your settings to make sure your web browser allows third-party cookies.
 
-### Allow guest access
+### HTTPS
+It is also a requirement that SAS Viya be accessed using the HTTPS protocol in order for web browsers to allow cross-site cookies to be set by SAS Viya. This requires that TLS (Transport Layer Security) be enabled on your SAS Viya deployment. See <a target="_blank" href="https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=calencryptmotion&docsetTarget=n1bktkey9qb5z0n14fji0ss0b453.htm#p11136ylabo3k1n1rwctv2xrn8js">SAS Help Center</a> for more information.
 
-The SAS Content SDK has the option to connect to the SAS Viya server using guest authentication. This requires that the SAS Viya system be
-set up to enable guest access, and that the guest user has access to the appropriate report content and data. For more information, see 
-<a target="_blank" href="https://go.documentation.sas.com/doc/en/sasadmincdc/v_023/calauthmdl/p1i1pi9jk2nkkqn1rkh3t5elvc9y.htm#n067qoyrgu1yohn19nq4ehy8o0b3">SAS Help Center</a>.
+## Allow guest access
+
+The SAS Content SDK has the option to connect to SAS Viya using guest authentication. This requires that SAS Viya be set up to enable guest access, and that the guest user has access to the appropriate report content and data. For more information, see 
+<a target="_blank" href="https://documentation.sas.com/doc/en/sasadmincdc/default/calauthmdl/n1iyx40th7exrqn1ej8t12gfhm88.htm#n067qoyrgu1yohn19nq4ehy8o0b3">SAS Help Center</a>.
 
 ## Finding Folder and Item URIs
 


### PR DESCRIPTION
When fixing #33 I saw that the content SDK viya setup doc links were pointing to the internal dev versions of the doc, not the production doc server.  Also, its viya setup doc had become out of sync with recent updates made to the VA SDK doc.  This fixes the links and updates the doc wording to be in sync with the VA SDK doc.