### PR TITLE
add documentation for object readyState and hideLoadImage

### DIFF
--- a/sdk/va-report-components/documentation/docs/api/ObjectHandle.md
+++ b/sdk/va-report-components/documentation/docs/api/ObjectHandle.md
@@ -11,6 +11,16 @@ When a report element is assigned new attribute values or removed from the DOM,
 any `ObjectHandles` obtained from that element are invalidated and should be
 discarded.
 
+## Properties
+
+###	readyState: string
+Describes the ready state of the report object. When this value changes, a `readyStateChanged` event is fired on the ObjectHandle. 
+
+This value can be one of the following:
+  - `"contentLoading"` when the report object is still loading its content.
+  - `"complete"` when the report object has finished loading.
+  - `"error"` when the report object encountered an error and could not load.
+
 ## Methods
 
 ### exportData(format: string, options?: ExportDataOptions): Promise\<string>
@@ -83,6 +93,7 @@ Adds an event listener to the `ObjectHandle` to call the supplied listener when 
 
 `eventType` is a string that represents the event type to listen for. These event types are supported:
 - `"selectionChanged"` for listening for selection changes in the object.
+- `"readyStateChanged"` for listening for changes in the object’s ready state.
 
 `listener` is an event listener callback function. When the event occurs, `listener` is called and passed an event object containing the following properties:
 - `type` is a string that matches the event type.

--- a/sdk/va-report-components/documentation/docs/api/ObjectHandle.md
+++ b/sdk/va-report-components/documentation/docs/api/ObjectHandle.md
@@ -14,7 +14,7 @@ discarded.
 ## Properties
 
 ### readyState: string
-Describes the ready state of the report object. When this value changes, a `readyStateChanged` event is fired on the ObjectHandle. 
+The ready state of the report object. When this value changes, a `readyStateChanged` event is fired on the ObjectHandle. 
 
 This value can be one of the following:
   - `"contentLoading"` when the report object is still loading its content.
@@ -93,7 +93,7 @@ Adds an event listener to the `ObjectHandle` to call the supplied listener when 
 
 `eventType` is a string that represents the event type to listen for. These event types are supported:
 - `"selectionChanged"` for listening for selection changes in the object.
-- `"readyStateChanged"` for listening for changes in the object’s ready state.
+- `"readyStateChanged"` for listening to changes on the `readyState` property.
 
 `listener` is an event listener callback function. When the event occurs, `listener` is called and passed an event object containing the following properties:
 - `type` is a string that matches the event type.

--- a/sdk/va-report-components/documentation/docs/api/ObjectHandle.md
+++ b/sdk/va-report-components/documentation/docs/api/ObjectHandle.md
@@ -13,7 +13,7 @@ discarded.
 
 ## Properties
 
-###	readyState: string
+### readyState: string
 Describes the ready state of the report object. When this value changes, a `readyStateChanged` event is fired on the ObjectHandle. 
 
 This value can be one of the following:

--- a/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
@@ -62,6 +62,12 @@ default value: `true`
 default value: `undefined`<br>
 default behavior: use a shared report context per report
 
+### `hideLoadImage: boolean`
+
+Indicates whether the static loading image displayed during object load should be hidden. When true, the report image is not displayed.
+
+default value: `false`
+
 
 ## Properties
 

--- a/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
+++ b/sdk/va-report-components/documentation/docs/api/SASReportObjectElement.md
@@ -64,7 +64,7 @@ default behavior: use a shared report context per report
 
 ### `hideLoadImage: boolean`
 
-Indicates whether the static loading image displayed during object load should be hidden. When true, the report image is not displayed.
+When `false`, report objects display a placeholder static image of the report object while it is loading. `true` hides this placeholder and displays a loading indicator.
 
 default value: `false`
 


### PR DESCRIPTION
Adds documentation for new object load related API.

- `readyState` property on ObjectHandle
- `readyStateChanged` event on ObjectHandle
- `hideLoadImage` on a SASReportObjectElement