### PR TITLE
Fix getting started link in doc

### DIFF
--- a/sdk/content-components/documentation/website/pages/en/index.js
+++ b/sdk/content-components/documentation/website/pages/en/index.js
@@ -57,7 +57,7 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle siteConfig={siteConfig} />
           <PromoSection>
-            <Button href="docs/getting-started">Get Started</Button>
+            <Button href={docUrl("getting-started")}>Get Started</Button>
           </PromoSection>
         </div>
       </SplashContainer>

--- a/sdk/va-report-components/documentation/website/pages/en/index.js
+++ b/sdk/va-report-components/documentation/website/pages/en/index.js
@@ -56,7 +56,7 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle siteConfig={siteConfig} />
           <PromoSection>
-            <Button href="docs/getting-started">Get Started</Button>
+            <Button href={docUrl("getting-started")}>Get Started</Button>
           </PromoSection>
         </div>
       </SplashContainer>


### PR DESCRIPTION
The relative link used for the "Get Started" link was causing issues when the developer.sas team was testing this out deployed on the new azure hosting for the updated site.  This fixes it, by constructing the link to use the full docs link, including the base url.  This is how other docs links are created throughout the doc, so this makes it consistent.

It is the same change for both va-report-components and content-components.